### PR TITLE
chore: add tsc and maintainer link

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,7 @@
 #
 # List of people required to get an approval from before landing any PRs
+# 
+# Alumni maintainers
+# @bajtos
 #
-* @bajtos @dhmlau @raymondfeng
+* @dhmlau @raymondfeng @marioestradarosa @achrinza @frbuceta

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A place for discussing "meta" topics around LoopBack project governance and team
 management.
 
+There are [Technical Steering Committee](https://github.com/loopbackio/loopback-next#technical-steering-committee) and [project maintainers](https://github.com/loopbackio/loopback-next#other-project-maintainers) maintaining this project.
+
 ## How to work in this repo
 
 1. Check the existing open issues for discussions in progress.


### PR DESCRIPTION
Signed-off-by: Diana Lau <dhmlau@ca.ibm.com>

A follow up PR from https://github.com/loopbackio/loopback-next/pull/8043 as suggested by @achrinza.
I also updated the `CODEOWNERS` to be tsc members.